### PR TITLE
Dynamic Brand

### DIFF
--- a/src/test/scala/ocaps/examples/Amplification.scala
+++ b/src/test/scala/ocaps/examples/Amplification.scala
@@ -24,7 +24,7 @@ object Amplification {
 
   case class Can(food: Brand.Box[Food])
 
-  class CanOpener(unsealer: Brand.Unsealer[Food]) {
+  class CanOpener(unsealer: Brand.Unsealer) {
     def open(can: Can): Food = {
       unsealer(can.food).get
     }
@@ -33,7 +33,7 @@ object Amplification {
   def main(args: Array[String]): Unit = {
     // We want to get at the food here.
 
-    val (sealer, unsealer) = Brand.create[Food]("canned food").tuple
+    val (sealer, unsealer) = Brand.create("canned food").tuple
     val canOfSpam: Can = Can(sealer(Food("spam")))
 
     // The can by itself has the food, but we have no way to get to it

--- a/src/test/scala/ocaps/examples/DynamicSeal.scala
+++ b/src/test/scala/ocaps/examples/DynamicSeal.scala
@@ -43,7 +43,7 @@ object DynamicSeal {
     name: String,
     sentencer: User => User = identity,
     boxed: Option[Brand.Box[Message]] = None,
-    private val brand: Option[Brand[Message]] = None
+    private val brand: Option[Brand] = None
   ) {
     def sentence(user: User): User = sentencer(user)
 
@@ -57,8 +57,8 @@ object DynamicSeal {
   }
 
   def main(args: Array[String]): Unit = {
-    val softBrand = Brand.create[Message]("Brand for Judge Softtouch")
-    val doomBrand = Brand.create[Message]("Brand for Judge Doom")
+    val softBrand = Brand.create("Brand for Judge Softtouch")
+    val doomBrand = Brand.create("Brand for Judge Doom")
 
     val judgeSofttouch = User("Judge Softtouch", sentencer = { user =>
       user.copy(boxed = Some(softBrand(Save)))

--- a/src/test/scala/ocaps/examples/experimental/Horton.scala
+++ b/src/test/scala/ocaps/examples/experimental/Horton.scala
@@ -1,58 +1,190 @@
 package ocaps.examples.experimental
 
+import ocaps.Brand
+import ocaps.Brand.Sealer
+
+import scala.collection.mutable
+import scala.language.dynamics
+
 class Horton {
+
+  // sealer(who) / unsealer(be)
 
   // http://www.erights.org/elib/capability/horton/horton-talk.pdf
   // http://www.erights.org/elib/capability/horton/amplify.html
   // http://www.erights.org/elib/capability/horton/base.html
   // http://www.erights.org/elib/capability/horton/
-  //
-  //  class A(b: B, c: C) {
-  //    def start {
-  //      b.foo(c)
-  //    }
-  //  }
-  //
-  //  class B {
-  //    def foo(c: C) = {
-  //      c.hi(c)
-  //    }
-  //  }
-  //
-  //  class C {
-  //    def hi(c: C) = println("hi")
-  //  }
-  //
-  //  def makePrincipal(label :String) {
-  //
-  //    def makeQuoteln(printer: String => Unit, message: String, indent: Int): Unit =  {
-  //      printer(message) // indent is not used right
-  //    }
-  //
-  //    def reportln = makeQuoteln(println, s"$label said:", 77)
-  //
-  //    val brand = ocaps.Brand.create(label)
-  //    val (whoMe, beMe) = brand.tuple
-  //  }
 
-  /*
-  def alice := makePsrincipal("Alice")
-  # value: Alice
+  class A(b: B, c: C) extends Dynamic {
+    def start= {
+      b.foo(c)
+    }
+  }
 
-  ? def bob := makePrincipal("Bob")
-  # value: Bob
+  class B extends Dynamic {
+    def foo(c: C) = {
+      c.hi(c)
+    }
+  }
 
-  ? def carol := makePrincipal("Carol")
-  # value: Carol
-  Initial connectiivity:
+  class C extends Dynamic {
+    def hi(c: C) = println("hi")
+  }
 
-  ? def gs1 := bob.encodeFor(b, alice.who())
+  // https://blog.scalac.io/2015/05/21/dynamic-member-lookup-in-scala.html
+  // https://stackoverflow.com/questions/15799811/how-does-type-dynamic-work-and-how-to-use-it
+  class Principal(label: String) extends Dynamic {
+    type Who = String
 
-  ? def gs2 := carol.encodeFor(c, alice.who())
+    private val brand = Brand.create(label)
 
-  ? def p1  := alice.decodeFrom(gs1, bob.who())
-  ? def p2  := alice.decodeFrom(gs2, carol.who())
-  ? def a := makeA(p1, p2)
+    def selectDynamic(name: String) = name
 
-   */
+    def who: Sealer = brand.sealer
+
+    def encodeFor[T](message: T, who: Sealer): Brand.Box[T] = ???
+
+    def decodeFrom[T](gs: Brand.Box[T], who: Sealer): T = ???
+
+    //    def principal {
+    //      to __printOn(out :TextWriter) {
+    //        out.print(label)
+    //      }
+    //      to who() {
+    //        return whoMe
+    //      }
+    //      to encodeFor(targ, whoBlame) {
+    //        def stub := makeStub(whoBlame, targ)
+    //        return wrap(stub, whoBlame)}
+    //      to decodeFrom(gift, whoBlame) {
+    //        def stub := unwrap(gift, whoBlame)
+    //        return makeProxy(whoBlame, stub)
+    //      }
+    //    }
+
+    //  def makeQuoteln := <elang:interp.makeQuoteln>
+    //  def makeBrand := <elib:sealing.makeBrand>
+    //  def makeWeakKeyMap := <unsafe:org.erights.e.elib.tables.makeWeakKeyMap> # added
+
+    private val proxyAmps = new mutable.WeakHashMap[Any, Any]()
+
+    // Returns stub?
+    private def makeStub(whoBlame: Sealer, targ: Any): Any = {
+      ???
+    }
+
+    //  # E sample
+    //
+    //def makePrincipal(label :String) {
+    //  def reportln := makeQuoteln(println, `$label said:`, 77)
+    //  def [whoMe, beMe] := makeBrand(label)
+    //  def proxyAmps := makeWeakKeyMap()                                   # added
+    //
+    //  def makeProxy(whoBlame, stub) {
+    //    def log := makeQuoteln(reportln,
+    //      `I ask ${whoBlame.getBrand()} to:`,
+    //      75)
+    //    def proxy {
+    //      # getGuts method removed
+    //
+    //      # as P1
+    //      match [verb, [p2]] {
+    //        log(`$verb/1`)
+    //        def [s2, whoCarol] := proxyAmps[p2]                     # changed
+    //        def gs3 := s2.intro(whoBlame)
+    //        def p3Desc := [gs3, whoCarol]
+    //        stub.deliver(verb, [p3Desc])
+    //      }
+    //    }
+    //    proxyAmps[proxy] := [stub, whoBlame]                            # added
+    //    return proxy
+    //  }
+    //
+    //  # as S2
+    //  def wrap(s3, whoBob) {
+    //    def provide(fillBox) {
+    //      def fill := beMe.unseal(fillBox)
+    //      fill(s3)
+    //    }
+    //    return whoBob.seal(provide)
+    //  }
+    //
+    //  # as S1
+    //  def unwrap(gs3, whoCarol) {
+    //    def provide := beMe.unseal(gs3)
+    //    var result := null
+    //    def fill(s3) {
+    //      result := s3
+    //    }
+    //    def fillBox := whoCarol.seal(fill)
+    //    provide(fillBox)
+    //    return result
+    //  }
+    //
+    //  def makeStub(whoBlame, targ) {
+    //    def log := makeQuoteln(reportln,
+    //      `${whoBlame.getBrand()} asks me to:`,
+    //      75)
+    //    def stub {
+    //      # as S2
+    //        to intro(whoBob) {
+    //        log(`meet ${whoBob.getBrand()}`)
+    //        def s3 := makeStub(whoBob, targ)
+    //        return wrap(s3, whoBob)
+    //      }
+    //      # as S1
+    //        to deliver(verb, [p3Desc]) {
+    //        log(`$verb/1`)
+    //        def [gs3, whoCarol] := p3Desc
+    //        def s3 := unwrap(gs3, whoCarol)
+    //        def p3 := makeProxy(whoCarol, s3)
+    //        E.call(targ, verb, [p3])
+    //      }
+    //    }
+    //    return stub
+    //  }
+    //
+    //  def principal {
+    //    to __printOn(out :TextWriter) {
+    //      out.print(label)
+    //    }
+    //    to who() {
+    //      return whoMe
+    //    }
+    //    to encodeFor(targ, whoBlame) {
+    //      def stub := makeStub(whoBlame, targ)
+    //      return wrap(stub, whoBlame)}
+    //    to decodeFrom(gift, whoBlame) {
+    //      def stub := unwrap(gift, whoBlame)
+    //      return makeProxy(whoBlame, stub)
+    //    }
+    //  }
+    //  return principal
+    //  }
+
+  }
+
+  object Principal {
+    def apply(name: String): Principal = ???
+  }
+
+  def main(args: Array[String]): Unit = {
+    val b = new B()
+    val c = new C()
+
+    val alice = Principal("Alice")
+    val bob = Principal("Bob")
+    val carol = Principal("Carol")
+
+    val gs1 = bob.encodeFor(b, alice.who)
+
+    val gs2 = carol.encodeFor(c, alice.who)
+
+    val p1: B = alice.decodeFrom(gs1, bob.who)
+    val p2: C = alice.decodeFrom(gs2, carol.who)
+    val a = new A(p1, p2)
+
+    a.start
+  }
+
 }

--- a/src/test/scala/ocaps/examples/experimental/SealingMembrane.scala
+++ b/src/test/scala/ocaps/examples/experimental/SealingMembrane.scala
@@ -2,24 +2,26 @@ package ocaps
 
 // construct a sealing monad, where the same unsealer is used for all boxes.
 
+object SealingMembrane {
 
-//trait BoxyBox[+T] {
-//  type C
-//}
-//
-//trait CanAccess {
-//  type C
-//}
-//
-//sealed trait Packed[+T] {
-//  val box: BoxyBox[T]
-//  val access: CanAccess { type C = box.C }
-//}
-//
-//class Foo {
-//  def doFoo(box: BoxyBox[Any])(implicit acc: CanAccess { type C = box.C }): Unit = {
-//    acc
-//  }
-//}
-//
-//new Foo()
+  //trait BoxyBox[+T] {
+  //  type C
+  //}
+  //
+  //trait CanAccess {
+  //  type C
+  //}
+  //
+  //sealed trait Packed[+T] {
+  //  val box: BoxyBox[T]
+  //  val access: CanAccess { type C = box.C }
+  //}
+  //
+  //class Foo {
+  //  def doFoo(box: BoxyBox[Any])(implicit acc: CanAccess { type C = box.C }): Unit = {
+  //    acc
+  //  }
+  //}
+  //
+  //new Foo()
+}


### PR DESCRIPTION
* Fix embarrassing bug where the sealer did not update contents correctly.  Now using AtomicReference / compareAndSet for lock-free updates.
* Move Brand to not have a type, move the type into the Box and manage type erasure.